### PR TITLE
Add permissions section to status output

### DIFF
--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -56,24 +56,10 @@ else
     echo "    Accessibility: ✗ (System Settings → Privacy & Security → Accessibility)"
 fi
 
-NOTIF_STATUS=$(hs_run '
-local n = hs.notify.new({title="__butthair_status_check"}):send()
-hs.timer.usleep(500000)
-local found = false
-for _, d in ipairs(hs.notify.deliveredNotifications()) do
-    if d:title() == "__butthair_status_check" then
-        found = true
-        d:withdraw()
-        break
-    end
-end
-return tostring(found)
-' || echo "false")
-if [ "$NOTIF_STATUS" = "true" ]; then
-    echo "    Notifications: ✓"
-else
-    echo "    Notifications: ✗ (System Settings → Notifications → Hammerspoon)"
-fi
+# Notification permissions can't be detected programmatically — send a visible check
+hs_run 'hs.notify.new({title="butthair", informativeText="Notification check — you should see this"}):send()' &>/dev/null || true
+echo "    Notifications: ? (a notification was just sent — did you see it?)"
+echo "                      If not → System Settings → Notifications → Hammerspoon"
 
 echo ""
 

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -45,13 +45,37 @@ if [ "$IPC_OK" = "false" ]; then
     exit 0
 fi
 
-# Accessibility
+# Permissions
+echo ""
+echo "  Permissions"
+
 ACCESS=$(hs_run "return hs.accessibilityState()" || echo "false")
 if [ "$ACCESS" = "true" ]; then
-    echo "  Accessibility: ✓"
+    echo "    Accessibility: ✓"
 else
-    echo "  Accessibility: ✗ (enable in System Settings → Privacy & Security → Accessibility)"
+    echo "    Accessibility: ✗ (System Settings → Privacy & Security → Accessibility)"
 fi
+
+NOTIF_STATUS=$(hs_run '
+local n = hs.notify.new({title="__butthair_status_check"}):send()
+hs.timer.usleep(500000)
+local found = false
+for _, d in ipairs(hs.notify.deliveredNotifications()) do
+    if d:title() == "__butthair_status_check" then
+        found = true
+        d:withdraw()
+        break
+    end
+end
+return tostring(found)
+' || echo "false")
+if [ "$NOTIF_STATUS" = "true" ]; then
+    echo "    Notifications: ✓"
+else
+    echo "    Notifications: ✗ (System Settings → Notifications → Hammerspoon)"
+fi
+
+echo ""
 
 # Screens
 SCREEN_COUNT=$(hs_run "return #hs.screen.allScreens()" || echo "?")

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -56,10 +56,25 @@ else
     echo "    Accessibility: ✗ (System Settings → Privacy & Security → Accessibility)"
 fi
 
-# Notification permissions can't be detected programmatically — send a visible check
-hs_run 'hs.notify.new({title="butthair", informativeText="Notification check — you should see this"}):send()' &>/dev/null || true
-echo "    Notifications: ? (a notification was just sent — did you see it?)"
-echo "                      If not → System Settings → Notifications → Hammerspoon"
+# Notification check — send hidden test notification, verify delivery, withdraw
+NOTIFY_RESULT=$(hs_run "$(cat <<'LUA'
+local n = hs.notify.new({title="__butthair_test__", informativeText="permission check"}):send()
+hs.timer.usleep(500000)
+local delivered = hs.notify.deliveredNotifications()
+for _, d in ipairs(delivered) do
+    if d:title() == "__butthair_test__" then
+        d:withdraw()
+        return "ok"
+    end
+end
+return "blocked"
+LUA
+)" 2>/dev/null || echo "blocked")
+if [ "$NOTIFY_RESULT" = "ok" ]; then
+    echo "    Notifications: ✓"
+else
+    echo "    Notifications: ✗ (System Settings → Notifications → Hammerspoon)"
+fi
 
 echo ""
 


### PR DESCRIPTION
## Summary

- Groups Accessibility and Notifications under a **Permissions** section in `butthair status`
- Adds notification delivery check: sends a hidden test notification, verifies it appears in `deliveredNotifications()`, and withdraws it
- Detects when macOS notifications are turned off for Hammerspoon with a helpful fix message

**Before:**
```
  Accessibility: ✓
  Screens:       1 (Odyssey G93SC)
```

**After:**
```
  Permissions
    Accessibility: ✓
    Notifications: ✓

  Screens:       1 (Odyssey G93SC)
```

## Test plan

- [x] `butthair status` shows Permissions section with both checks passing
- [x] Notification check correctly detects enabled state
- [ ] Notification check detects disabled state (turn off in System Settings → Notifications → Hammerspoon)