### PR TITLE
Fix CALLER_PWD env var to match shiv shim

### DIFF
--- a/.mise/tasks/screenshot
+++ b/.mise/tasks/screenshot
@@ -9,7 +9,7 @@ source "$TASKS_DIR/_hs"
 hs_check
 hs_check_screen_recording
 
-CALLER_DIR="${BUTTHAIR_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
 OUTPUT="${usage_output}"
 
 # Resolve relative paths to caller's directory

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Output shell configuration for global butthair command (use with eval)"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-echo "alias butthair='BUTTHAIR_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"
+echo "alias butthair='CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"


### PR DESCRIPTION
## Summary

- Tasks read `BUTTHAIR_CALLER_PWD`, but shiv's shim exports `CALLER_PWD`
- Same bug fixed in monkeys#32 and ghpm — standardizing across all shiv-installed packages

## Test plan

- [ ] `butthair screenshot -o shot.png` saves to caller's directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)