### PR TITLE
feat: add BATS tests, README.tsx, and readme pre-commit hook

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS tests"
-#USAGE arg "[files]" var=#true help="Specific test files to run (default: all)"
 set -euo pipefail
 
-ARGS=()
-if [ -n "${usage_files:-}" ]; then
-  while IFS= read -r arg; do
-    ARGS+=("$arg")
-  done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
-else
-  ARGS=("$MISE_CONFIG_ROOT/test/")
-fi
+TEST_DIR="$MISE_CONFIG_ROOT/test"
 
-bats "${ARGS[@]}"
+if [ $# -eq 0 ]; then
+  bats "$TEST_DIR/"
+else
+  args=()
+  for arg in "$@"; do
+    if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+      args+=("$TEST_DIR/$arg.bats")
+    else
+      args+=("$arg")
+    fi
+  done
+  bats "${args[@]}"
+fi

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-#MISE description="Run test suite"
-#MISE hide=true
+#MISE description="Run BATS tests"
+#USAGE arg "[files]" var=#true help="Specific test files to run (default: all)"
 set -euo pipefail
 
-bats test/
+ARGS=()
+if [ -n "${usage_files:-}" ]; then
+  while IFS= read -r arg; do
+    ARGS+=("$arg")
+  done < <(printf '%s' "${usage_files}" | xargs printf '%s\n')
+else
+  ARGS=("$MISE_CONFIG_ROOT/test/")
+fi
+
+bats "${ARGS[@]}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run test suite"
+#MISE hide=true
+set -euo pipefail
+
+bats test/

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS tests"
+#USAGE arg "[args]..." var=#true help="Test suites or bats arguments"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test validation" header="Run a specific suite by name"
+#USAGE example "mise run test test/status.bats" header="Run a specific file"
+#USAGE example "mise run test -- --filter rejects" header="Filter tests by name"
 set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"
@@ -8,12 +13,19 @@ if [ $# -eq 0 ]; then
   bats "$TEST_DIR/"
 else
   args=()
+  has_target=false
   for arg in "$@"; do
     if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
       args+=("$TEST_DIR/$arg.bats")
+      has_target=true
     else
+      [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
       args+=("$arg")
     fi
   done
+  # If only flags were passed (e.g. --filter), append the default test dir
+  if ! $has_target; then
+    args+=("$TEST_DIR/")
+  fi
   bats "${args[@]}"
 fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+<div align="center">
+
+# butthair
+
+**Desktop automation for macOS via Hammerspoon.**
+
+Shell commands for windows, spaces, screenshots, keyboards, and notifications.
+No Lua required — just bash tasks that talk to the Hammerspoon API.
+
+![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
+[![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
+![tasks: 21](https://img.shields.io/badge/tasks-21-blue?style=flat)
+![tests: 20](https://img.shields.io/badge/tests-20-green?style=flat)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
+
+</div>
+
+## How it works
+
+Every command is a mise task that calls Hammerspoon's `hs` CLI with a Lua expression. The `_hs` helper handles CLI discovery, process checks, input validation, and IPC health — tasks stay thin.
+
+```bash
+# Move a window to the left half of the screen
+butthair windows:move "Arc" --x 0 --y 0 --w 960 --h 1080
+
+# Switch to space 3
+butthair spaces:goto 3
+
+# Take a screenshot
+butthair screenshot
+
+# Check everything's healthy
+butthair status
+```
+
+## Install
+
+```bash
+shiv install butthair
+```
+
+Requires [Hammerspoon](https://www.hammerspoon.org/) — install it with `butthair install` or download from the website.
+
+## Tasks
+
+| Task             | Description                                                            |
+| ---------------- | ---------------------------------------------------------------------- |
+| `notify`         | Send a system notification                                             |
+| `screenshot`     | Capture a screenshot                                                   |
+| `install`        | Install or upgrade Hammerspoon                                         |
+| `shell`          | Output shell configuration for global butthair command (use with eval) |
+| `setup`          | Initial Hammerspoon setup for butthair                                 |
+| `spaces:remove`  | Remove a space by index number                                         |
+| `spaces:goto`    | Switch to a space by index number                                      |
+| `spaces:add`     | Add a new space                                                        |
+| `spaces:current` | Show the current space index and ID                                    |
+| `spaces:list`    | List all spaces with IDs and types                                     |
+| `status`         | Check Hammerspoon installation and status                              |
+| `restart`        | Restart Hammerspoon and wait for IPC                                   |
+| `uninstall`      | Uninstall Hammerspoon                                                  |
+| `logs`           | Show Hammerspoon console logs                                          |
+| `screen:info`    | Show screen dimensions and info                                        |
+| `windows:move`   | Move/resize a window by app name                                       |
+| `windows:close`  | Close a window by ID                                                   |
+| `windows:launch` | Launch an app and optionally position its window                       |
+| `windows:list`   | List all windows                                                       |
+| `keyboard:press` | Press a key combination                                                |
+| `keyboard:type`  | Type a string of text                                                  |
+
+## Development
+
+```bash
+gh repo clone KnickKnackLabs/butthair
+cd butthair && mise trust && mise install
+mise run test   # 20 tests
+```
+
+<div align="center">
+
+## License
+
+MIT
+
+This README was created using [readme](https://github.com/KnickKnackLabs/readme).
+
+</div>

--- a/README.tsx
+++ b/README.tsx
@@ -1,0 +1,149 @@
+/** @jsxImportSource jsx-md */
+
+import { readdirSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+
+import {
+  Heading, Paragraph, CodeBlock,
+  Bold, Code, Link,
+  Badge, Badges, Center, Section,
+  Table, TableHead, TableRow, Cell,
+} from "readme/src/components";
+
+// ── Dynamic data ─────────────────────────────────────────────
+
+const REPO_DIR = resolve(import.meta.dirname);
+
+// Count tasks (excluding _hs helper and test)
+function countTasks(dir: string, prefix = ""): string[] {
+  const tasks: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith("_")) continue;
+    if (entry.name === "test") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      tasks.push(...countTasks(full, `${prefix}${entry.name}:`));
+    } else {
+      tasks.push(`${prefix}${entry.name}`);
+    }
+  }
+  return tasks;
+}
+
+const taskDir = join(REPO_DIR, ".mise/tasks");
+const tasks = countTasks(taskDir);
+
+// Parse task descriptions
+const taskInfo = tasks.map((name) => {
+  const filePath = join(taskDir, name.replace(/:/g, "/"));
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/#MISE description="(.+?)"/);
+  return { name, desc: match?.[1] ?? "" };
+});
+
+// Count tests from .bats files
+const testDir = join(REPO_DIR, "test");
+const testCount = readdirSync(testDir)
+  .filter((f) => f.endsWith(".bats"))
+  .reduce((sum, f) => {
+    const content = readFileSync(join(testDir, f), "utf-8");
+    return sum + (content.match(/@test /g) || []).length;
+  }, 0);
+
+// Group tasks by namespace
+const namespaces = new Map<string, typeof taskInfo>();
+for (const t of taskInfo) {
+  const ns = t.name.includes(":") ? t.name.split(":")[0] : "(root)";
+  if (!namespaces.has(ns)) namespaces.set(ns, []);
+  namespaces.get(ns)!.push(t);
+}
+
+// ── README ───────────────────────────────────────────────────
+
+const readme = (
+  <>
+    <Center>
+      <Heading level={1}>butthair</Heading>
+
+      <Paragraph>
+        <Bold>Desktop automation for macOS via Hammerspoon.</Bold>
+      </Paragraph>
+
+      <Paragraph>
+        Shell commands for windows, spaces, screenshots, keyboards, and notifications.{"\n"}
+        No Lua required — just bash tasks that talk to the Hammerspoon API.
+      </Paragraph>
+
+      <Badges>
+        <Badge label="shell" value="bash" color="4EAA25" logo="gnubash" logoColor="white" />
+        <Badge label="runtime" value="mise" color="7c3aed" href="https://mise.jdx.dev" />
+        <Badge label="tasks" value={`${tasks.length}`} color="blue" />
+        <Badge label="tests" value={`${testCount}`} color="green" />
+        <Badge label="License" value="MIT" color="blue" href="LICENSE" />
+      </Badges>
+    </Center>
+
+    <Section title="How it works">
+      <Paragraph>
+        Every command is a mise task that calls Hammerspoon's <Code>hs</Code> CLI
+        with a Lua expression. The <Code>_hs</Code> helper handles CLI discovery,
+        process checks, input validation, and IPC health — tasks stay thin.
+      </Paragraph>
+
+      <CodeBlock lang="bash">{`# Move a window to the left half of the screen
+butthair windows:move "Arc" --x 0 --y 0 --w 960 --h 1080
+
+# Switch to space 3
+butthair spaces:goto 3
+
+# Take a screenshot
+butthair screenshot
+
+# Check everything's healthy
+butthair status`}</CodeBlock>
+    </Section>
+
+    <Section title="Install">
+      <CodeBlock lang="bash">{`shiv install butthair`}</CodeBlock>
+
+      <Paragraph>
+        Requires <Link href="https://www.hammerspoon.org/">Hammerspoon</Link> — install
+        it with <Code>butthair install</Code> or download from the website.
+      </Paragraph>
+    </Section>
+
+    <Section title="Tasks">
+      <Table>
+        <TableHead>
+          <Cell>Task</Cell>
+          <Cell>Description</Cell>
+        </TableHead>
+        {taskInfo.map((t) => (
+          <TableRow>
+            <Cell><Code>{t.name}</Code></Cell>
+            <Cell>{t.desc}</Cell>
+          </TableRow>
+        ))}
+      </Table>
+    </Section>
+
+    <Section title="Development">
+      <CodeBlock lang="bash">{`gh repo clone KnickKnackLabs/butthair
+cd butthair && mise trust && mise install
+mise run test   # ${testCount} tests`}</CodeBlock>
+    </Section>
+
+    <Center>
+      <Section title="License">
+        <Paragraph>MIT</Paragraph>
+      </Section>
+
+      <Paragraph>
+        {"This README was created using "}
+        <Link href="https://github.com/KnickKnackLabs/readme">readme</Link>.
+      </Paragraph>
+    </Center>
+  </>
+);
+
+console.log(readme);

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 gum = "latest"
+bats = "1.13.0"
+bun = "1"

--- a/test/status.bats
+++ b/test/status.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# Integration tests — require Hammerspoon running with IPC
+
+setup() {
+  load test_helper
+
+  # Skip all if Hammerspoon isn't running with IPC
+  if ! pgrep -x "Hammerspoon" > /dev/null 2>&1; then
+    skip "Hammerspoon not running"
+  fi
+  if ! "$HS_CLI" -c "return [[ok]]" > /dev/null 2>&1; then
+    skip "Hammerspoon IPC not responding"
+  fi
+}
+
+@test "status runs successfully" {
+  run butthair status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"butthair status"* ]]
+}
+
+@test "status shows installation" {
+  run butthair status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Installed:"* ]]
+}
+
+@test "status shows permissions section" {
+  run butthair status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Permissions"* ]]
+  [[ "$output" == *"Accessibility:"* ]]
+  [[ "$output" == *"Notifications:"* ]]
+}
+
+@test "status shows screen info" {
+  run butthair status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Screens:"* ]]
+}
+
+@test "status shows window count" {
+  run butthair status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Windows:"* ]]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Resolve repo directory
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Source the shared HS helper for access to validation functions
+source "$REPO_DIR/.mise/tasks/_hs"
+
+# Wrapper to run butthair tasks through mise
+butthair() {
+  cd "$REPO_DIR" && mise run -q "$@"
+}
+export -f butthair

--- a/test/validation.bats
+++ b/test/validation.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+}
+
+# ── hs_validate_app ──────────────────────────────────────────
+
+@test "hs_validate_app accepts simple app name" {
+  run hs_validate_app "Safari"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_app accepts app name with spaces" {
+  run hs_validate_app "Google Chrome"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_app accepts app name with dots and dashes" {
+  run hs_validate_app "com.apple.Safari-2.0"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_app rejects shell metacharacters" {
+  run hs_validate_app 'foo; rm -rf /'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid app name"* ]]
+}
+
+@test "hs_validate_app rejects backticks" {
+  run hs_validate_app 'foo`whoami`'
+  [ "$status" -eq 1 ]
+}
+
+@test "hs_validate_app rejects dollar signs" {
+  run hs_validate_app 'foo$HOME'
+  [ "$status" -eq 1 ]
+}
+
+# ── hs_validate_lua_str ─────────────────────────────────────
+
+@test "hs_validate_lua_str accepts normal string" {
+  run hs_validate_lua_str "hello world"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_lua_str accepts string with single brackets" {
+  run hs_validate_lua_str "foo]bar[baz"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_lua_str rejects double closing brackets" {
+  run hs_validate_lua_str 'foo]]bar'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must not contain"* ]]
+}
+
+# ── hs_validate_num ──────────────────────────────────────────
+
+@test "hs_validate_num accepts positive integer" {
+  run hs_validate_num "42"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_num accepts negative integer" {
+  run hs_validate_num "-7"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_num accepts zero" {
+  run hs_validate_num "0"
+  [ "$status" -eq 0 ]
+}
+
+@test "hs_validate_num rejects float" {
+  run hs_validate_num "3.14"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"expected number"* ]]
+}
+
+@test "hs_validate_num rejects string" {
+  run hs_validate_num "abc"
+  [ "$status" -eq 1 ]
+}
+
+@test "hs_validate_num rejects empty string" {
+  run hs_validate_num ""
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Brings butthair up to KKL codebase conventions before tagging v0.1.0.

## Tests (20)

- **validation.bats** — unit tests for `_hs` input validators (`hs_validate_app`, `hs_validate_lua_str`, `hs_validate_num`). No Hammerspoon required.
- **status.bats** — integration tests for `butthair status` output sections. Requires running Hammerspoon with IPC; skips gracefully otherwise.

## README

- `README.tsx` using KnickKnackLabs/readme JSX pipeline
- Dynamic task count and test count from codebase scan
- Pre-commit hook (`--build` mode) keeps README.md in sync

## mise.toml

- Added `bats = "1.13.0"` and `bun = "1"` for tests and readme build